### PR TITLE
Feature/25 populate parent type

### DIFF
--- a/src/models/ResourceInstance.ts
+++ b/src/models/ResourceInstance.ts
@@ -113,4 +113,5 @@ export const resourceInstanceSerializer = new Serializer('resourceInstance', {
     'attributes',
     'resourceType',
   ],
+  keyForAttribute: 'camelCase',
 });

--- a/src/routes/resourceInstances.ts
+++ b/src/routes/resourceInstances.ts
@@ -11,22 +11,22 @@ const populateResourceTypeOptions = {
   model: 'ResourceType',
 };
 
-  /**
-   * @swagger
-   *
-   *  /resource-instances:
-   *    get:
-   *      summary: Get list of all resource instances
-   *      tags:
-   *        - ResourceInstances
-   *      responses:
-   *        '200':
-   *          description: Successful
-   *          content:
-   *            application/vnd.api+json:
-   *              schema:
-   *                $ref: '#/components/schemas/ResourceInstancesResponse'
-   */
+/**
+ * @swagger
+ *
+ *  /resource-instances:
+ *    get:
+ *      summary: Get list of all resource instances
+ *      tags:
+ *        - ResourceInstances
+ *      responses:
+ *        '200':
+ *          description: Successful
+ *          content:
+ *            application/vnd.api+json:
+ *              schema:
+ *                $ref: '#/components/schemas/ResourceInstancesResponse'
+ */
 router.get('/', async (req: express.Request, res: express.Response) => {
   try {
     const resourceInstances = await ResourceInstance
@@ -40,29 +40,29 @@ router.get('/', async (req: express.Request, res: express.Response) => {
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-instances/{id}:
-   *    get:
-   *      summary: Get a resource instance by ID
-   *      tags:
-   *        - ResourceInstances
-   *      parameters:
-   *        - name: id
-   *          in: path
-   *          description: Resource-Instance ID
-   *          required: true
-   *          schema:
-   *            type: string
-   *      responses:
-   *        '200':
-   *          description: Successful
-   *          content:
-   *            application/vnd.api+json:
-   *              schema:
-   *                $ref: '#/components/schemas/ResourceInstanceResponse'
-   */
+/**
+ * @swagger
+ *
+ *  /resource-instances/{id}:
+ *    get:
+ *      summary: Get a resource instance by ID
+ *      tags:
+ *        - ResourceInstances
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: Resource-Instance ID
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        '200':
+ *          description: Successful
+ *          content:
+ *            application/vnd.api+json:
+ *              schema:
+ *                $ref: '#/components/schemas/ResourceInstanceResponse'
+ */
 router.get('/:instanceId', async (req: express.Request, res: express.Response) => {
   try {
     const resourceInstance = await ResourceInstance
@@ -76,22 +76,22 @@ router.get('/:instanceId', async (req: express.Request, res: express.Response) =
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-instances:
-   *    post:
-   *      summary: Create a new resource instance
-   *      tags:
-   *        - ResourceInstances
-   *      responses:
-   *        '201':
-   *          description: Successful
-   *          content:
-   *            application/vnd.api+json:
-   *              schema:
-   *                $ref: '#/components/schemas/ResourceInstanceResponse'
-   */
+/**
+ * @swagger
+ *
+ *  /resource-instances:
+ *    post:
+ *      summary: Create a new resource instance
+ *      tags:
+ *        - ResourceInstances
+ *      responses:
+ *        '201':
+ *          description: Successful
+ *          content:
+ *            application/vnd.api+json:
+ *              schema:
+ *                $ref: '#/components/schemas/ResourceInstanceResponse'
+ */
 router.post('/', async (req: express.Request, res: express.Response) => {
   try {
     const newInstanceJSON = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
@@ -104,25 +104,25 @@ router.post('/', async (req: express.Request, res: express.Response) => {
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-instances/{id}:
-   *    patch:
-   *      summary: Update a resource instance with a given ID
-   *      tags:
-   *        - ResourceInstances
-   *      parameters:
-   *        - name: id
-   *          in: path
-   *          description: Resource-Instance ID
-   *          required: true
-   *          schema:
-   *            type: string
-   *      responses:
-   *        '200':
-   *          description: Successfully updated
-   */
+/**
+ * @swagger
+ *
+ *  /resource-instances/{id}:
+ *    patch:
+ *      summary: Update a resource instance with a given ID
+ *      tags:
+ *        - ResourceInstances
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: Resource-Instance ID
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        '200':
+ *          description: Successfully updated
+ */
 router.patch('/:instanceId', async (req: express.Request, res: express.Response) => {
   try {
     const newAttributeValues = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
@@ -143,25 +143,25 @@ router.patch('/:instanceId', async (req: express.Request, res: express.Response)
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-instances/{id}:
-   *    delete:
-   *      summary: Delete a resource instance with a given ID
-   *      tags:
-   *        - ResourceInstances
-   *      parameters:
-   *        - name: id
-   *          in: path
-   *          description: Resource-Instance ID
-   *          required: true
-   *          schema:
-   *            type: string
-   *      responses:
-   *        '204':
-   *          description: Successfully deleted
-   */
+/**
+ * @swagger
+ *
+ *  /resource-instances/{id}:
+ *    delete:
+ *      summary: Delete a resource instance with a given ID
+ *      tags:
+ *        - ResourceInstances
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: Resource-Instance ID
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        '204':
+ *          description: Successfully deleted
+ */
 router.delete('/:instanceId', async (req: express.Request, res: express.Response) => {
   try {
     const resourceInstance = await ResourceInstance.findById(req.params.instanceId).exec();

--- a/src/routes/resourceInstances.ts
+++ b/src/routes/resourceInstances.ts
@@ -6,6 +6,11 @@ import createJSONError from '@/utils/errorSerializer';
 
 const router: express.Router = express.Router();
 
+const populateResourceTypeOptions = {
+  path: 'resourceType',
+  model: 'ResourceType',
+};
+
   /**
    * @swagger
    *
@@ -24,7 +29,10 @@ const router: express.Router = express.Router();
    */
 router.get('/', async (req: express.Request, res: express.Response) => {
   try {
-    const resourceInstances = await ResourceInstance.find({}).exec();
+    const resourceInstances = await ResourceInstance
+      .find({})
+      .populate(populateResourceTypeOptions)
+      .exec();
     res.send(resourceInstanceSerializer.serialize(resourceInstances));
   } catch (error) {
     winston.error(error.message);
@@ -57,7 +65,10 @@ router.get('/', async (req: express.Request, res: express.Response) => {
    */
 router.get('/:instanceId', async (req: express.Request, res: express.Response) => {
   try {
-    const resourceInstance = await ResourceInstance.findById(req.params.instanceId).exec();
+    const resourceInstance = await ResourceInstance
+      .findById(req.params.instanceId)
+      .populate(populateResourceTypeOptions)
+      .exec();
     res.send(resourceInstanceSerializer.serialize(resourceInstance));
   } catch (error) {
     winston.error(error.message);

--- a/src/routes/resourceTypes.ts
+++ b/src/routes/resourceTypes.ts
@@ -11,22 +11,22 @@ const populateParentTypeOptions = {
   model: 'ResourceType',
 };
 
-  /**
-   * @swagger
-   *
-   *  /resource-types:
-   *    get:
-   *      summary: Get list of all resource types
-   *      tags:
-   *        - ResourceTypes
-   *      responses:
-   *        '200':
-   *          description: Successful
-   *          content:
-   *            application/vnd.api+json:
-   *              schema:
-   *                $ref: '#/components/schemas/ResourceTypesResponse'
-   */
+/**
+ * @swagger
+ *
+ *  /resource-types:
+ *    get:
+ *      summary: Get list of all resource types
+ *      tags:
+ *        - ResourceTypes
+ *      responses:
+ *        '200':
+ *          description: Successful
+ *          content:
+ *            application/vnd.api+json:
+ *              schema:
+ *                $ref: '#/components/schemas/ResourceTypesResponse'
+ */
 router.get('/', async (req: express.Request, res: express.Response) => {
   try {
     const resourceTypes = await ResourceTypeModel
@@ -43,29 +43,29 @@ router.get('/', async (req: express.Request, res: express.Response) => {
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-types/{id}:
-   *    get:
-   *      summary: Get a resource type by ID
-   *      tags:
-   *        - ResourceTypes
-   *      parameters:
-   *        - name: id
-   *          in: path
-   *          description: Resource-Type ID
-   *          required: true
-   *          schema:
-   *            type: string
-   *      responses:
-   *        '200':
-   *          description: Successful
-   *          content:
-   *            application/vnd.api+json:
-   *              schema:
-   *                $ref: '#/components/schemas/ResourceTypeResponse'
-   */
+/**
+ * @swagger
+ *
+ *  /resource-types/{id}:
+ *    get:
+ *      summary: Get a resource type by ID
+ *      tags:
+ *        - ResourceTypes
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: Resource-Type ID
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        '200':
+ *          description: Successful
+ *          content:
+ *            application/vnd.api+json:
+ *              schema:
+ *                $ref: '#/components/schemas/ResourceTypeResponse'
+ */
 router.get('/:typeId', async (req: express.Request, res: express.Response) => {
   try {
     const resourceType = await ResourceTypeModel
@@ -83,22 +83,22 @@ router.get('/:typeId', async (req: express.Request, res: express.Response) => {
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-types:
-   *    post:
-   *      summary: Create a new resource type
-   *      tags:
-   *        - ResourceTypes
-   *      responses:
-   *        '201':
-   *          description: Successful
-   *          content:
-   *            application/vnd.api+json:
-   *              schema:
-   *                $ref: '#/components/schemas/ResourceTypeResponse'
-   */
+/**
+ * @swagger
+ *
+ *  /resource-types:
+ *    post:
+ *      summary: Create a new resource type
+ *      tags:
+ *        - ResourceTypes
+ *      responses:
+ *        '201':
+ *          description: Successful
+ *          content:
+ *            application/vnd.api+json:
+ *              schema:
+ *                $ref: '#/components/schemas/ResourceTypeResponse'
+ */
 router.post('/', async (req: express.Request, res: express.Response) => {
   try {
     const newResourceTypeJSON = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
@@ -111,25 +111,25 @@ router.post('/', async (req: express.Request, res: express.Response) => {
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-types/{id}:
-   *    patch:
-   *      summary: Update a resource type with a given ID
-   *      tags:
-   *        - ResourceTypes
-   *      parameters:
-   *        - name: id
-   *          in: path
-   *          description: Resource-Type ID
-   *          required: true
-   *          schema:
-   *            type: string
-   *      responses:
-   *        '200':
-   *          description: Successfully updated
-   */
+/**
+ * @swagger
+ *
+ *  /resource-types/{id}:
+ *    patch:
+ *      summary: Update a resource type with a given ID
+ *      tags:
+ *        - ResourceTypes
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: Resource-Type ID
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        '200':
+ *          description: Successfully updated
+ */
 router.patch('/:typeId', async (req: express.Request, res: express.Response) => {
   try {
     const newAttributeValues = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
@@ -150,25 +150,25 @@ router.patch('/:typeId', async (req: express.Request, res: express.Response) => 
   }
 });
 
-  /**
-   * @swagger
-   *
-   *  /resource-types/{id}:
-   *    delete:
-   *      summary: Delete a resource type with a given ID
-   *      tags:
-   *        - ResourceTypes
-   *      parameters:
-   *        - name: id
-   *          in: path
-   *          description: Resource-Type ID
-   *          required: true
-   *          schema:
-   *            type: string
-   *      responses:
-   *        '204':
-   *          description: Successfully deleted
-   */
+/**
+ * @swagger
+ *
+ *  /resource-types/{id}:
+ *    delete:
+ *      summary: Delete a resource type with a given ID
+ *      tags:
+ *        - ResourceTypes
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: Resource-Type ID
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        '204':
+ *          description: Successfully deleted
+ */
 router.delete('/:typeId', async (req: express.Request, res: express.Response) => {
   try {
     const resourceType = await ResourceTypeModel.findById(req.params.typeId).exec();

--- a/src/routes/resourceTypes.ts
+++ b/src/routes/resourceTypes.ts
@@ -6,6 +6,11 @@ import createJSONError from '@/utils/errorSerializer';
 
 const router: express.Router = express.Router();
 
+const populateParentTypeOptions = {
+  path: 'parentType',
+  model: 'ResourceType',
+};
+
   /**
    * @swagger
    *
@@ -24,7 +29,10 @@ const router: express.Router = express.Router();
    */
 router.get('/', async (req: express.Request, res: express.Response) => {
   try {
-    const resourceTypes = await ResourceTypeModel.find({}).exec();
+    const resourceTypes = await ResourceTypeModel
+      .find({})
+      .populate(populateParentTypeOptions)
+      .exec();
     for (const resourceType of resourceTypes) {
       resourceType.attributes = await resourceType.getCompleteListOfAttributes();
     }
@@ -60,7 +68,10 @@ router.get('/', async (req: express.Request, res: express.Response) => {
    */
 router.get('/:typeId', async (req: express.Request, res: express.Response) => {
   try {
-    const resourceType = await ResourceTypeModel.findById(req.params.typeId).exec();
+    const resourceType = await ResourceTypeModel
+      .findById(req.params.typeId)
+      .populate(populateParentTypeOptions)
+      .exec();
     if (!resourceType) {
       throw Error(`Resource type with id ${req.params.id} could not be found.`);
     }


### PR DESCRIPTION
- On the resource-type/resource-instances route, populated `parentType` / `resourceType` attributes are returned.
- The population has only a depth of one level. (The `parentType` attribute of a populated type will remain an ID.)