### PR TITLE
Hotfix/json api populated fields

### DIFF
--- a/src/models/ResourceAttribute.ts
+++ b/src/models/ResourceAttribute.ts
@@ -6,23 +6,20 @@ import { prop } from 'typegoose';
  *  components:
  *    schemas:
  *      ResourceAttribute:
- *        allOf:
- *          - $ref: '#/components/schemas/JsonApiObject'
- *          - type: object
- *            properties:
- *              attributes:
- *                type: object
- *                required:
- *                  - name
- *                  - dataType
- *                  - required
- *                properties:
- *                  name:
- *                    type: string
- *                  dataType:
- *                    type: string
- *                  required:
- *                    type: boolean
+ *        type: object
+ *        required:
+ *          - name
+ *          - dataType
+ *          - required
+ *        properties:
+ *          id:
+ *            type: string
+ *          name:
+ *            type: string
+ *          dataType:
+ *            type: string
+ *          required:
+ *            type: boolean
  */
 
 export default class ResourceAttribute {

--- a/src/models/ResourceAttributeValue.ts
+++ b/src/models/ResourceAttributeValue.ts
@@ -6,20 +6,15 @@ import { prop } from 'typegoose';
  *  components:
  *    schemas:
  *      ResourceAttributeValue:
- *        allOf:
- *          - $ref: '#/components/schemas/JsonApiObject'
- *          - type: object
- *            properties:
- *              attributes:
- *                type: object
- *                required:
- *                  - name
- *                  - value
- *                properties:
- *                  name:
- *                    type: string
- *                  value:
- *                    type: string
+ *        type: object
+ *        required:
+ *          - name
+ *          - value
+ *        properties:
+ *          name:
+ *            type: string
+ *          value:
+ *            type: string
  */
 
 export default class ResourceAttributeValue {

--- a/src/models/ResourceInstance.ts
+++ b/src/models/ResourceInstance.ts
@@ -113,5 +113,16 @@ export const resourceInstanceSerializer = new Serializer('resourceInstance', {
     'attributes',
     'resourceType',
   ],
+  resourceType: {
+    ref: '_id',
+    type: 'resourceType',
+    attributes: [
+      'name',
+      'abstract',
+      'attributes',
+      'parentType',
+      'eponymousAttribute',
+    ],
+  },
   keyForAttribute: 'camelCase',
-});
+} as any);

--- a/src/models/ResourceInstance.ts
+++ b/src/models/ResourceInstance.ts
@@ -58,8 +58,20 @@ import winston from 'winston';
  *                    type: array
  *                    items:
  *                      $ref: '#/components/schemas/ResourceAttributeValue'
- *                  resourceType:
- *                    $ref: '#/components/schemas/ResourceType'
+ *      PopulatedResourceInstance:
+ *        allOf:
+ *          - $ref: '#/components/schemas/ResourceInstance'
+ *          - type: object
+ *            properties:
+ *              relationships:
+ *                $ref: '#/components/schemas/ResourceTypeRelationship'
+ *      FlatResourceInstance:
+ *        allOf:
+ *          - $ref: '#/components/schemas/ResourceInstance'
+ *          - type: object
+ *            properties:
+ *              resourceType:
+ *                type: string
  */
 
 export class ResourceInstance extends Typegoose {

--- a/src/models/ResourceType.ts
+++ b/src/models/ResourceType.ts
@@ -157,5 +157,16 @@ export const resourceTypeSerializer = new Serializer('resourceType', {
     'parentType',
     'eponymousAttribute',
   ],
+  parentType: {
+    ref: '_id',
+    type: 'resourceType',
+    attributes: [
+      'name',
+      'abstract',
+      'attributes',
+      'parentType',
+      'eponymousAttribute',
+    ],
+  },
   keyForAttribute: 'camelCase',
-});
+} as any);

--- a/src/models/ResourceType.ts
+++ b/src/models/ResourceType.ts
@@ -55,9 +55,24 @@ import { ObjectId } from 'bson';
  *                    items:
  *                      $ref: '#/components/schemas/ResourceAttribute'
  *                  eponymousAttribute:
- *                    $ref: '#/components/schemas/ResourceAttribute'
+ *                    type: string
+ *      PopulatedResourceType:
+ *        allOf:
+ *          - $ref: '#/components/schemas/ResourceType'
+ *          - type: object
+ *            properties:
+ *              relationships:
+ *                $ref: '#/components/schemas/ParentTypeRelationship'
+ *      FlatResourceType:
+ *        allOf:
+ *          - $ref: '#/components/schemas/ResourceType'
+ *          - type: object
+ *            properties:
+ *              attributes:
+ *                type: object
+ *                properties:
  *                  parentType:
- *                    $ref: '#/components/schemas/ResourceType'
+ *                    type: string
  */
 
 export class ResourceType extends Typegoose {

--- a/src/models/swagger/JsonApiObject.yaml
+++ b/src/models/swagger/JsonApiObject.yaml
@@ -10,3 +10,13 @@ components:
           type: string
         id:
           type: string
+    RelationshipObject:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            type:
+              type: string
+            id:
+              type: string

--- a/src/models/swagger/ResponseObjects.yaml
+++ b/src/models/swagger/ResponseObjects.yaml
@@ -4,24 +4,49 @@ components:
       type: object
       properties:
         data:
-          $ref: '#/components/schemas/ResourceType'
+          $ref: '#/components/schemas/PopulatedResourceType'
+        included:
+          type: array
+          items:
+            $ref: '#/components/schemas/FlatResourceType'
     ResourceTypesResponse:
       type: object
       properties:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/ResourceType'
-
+            $ref: '#/components/schemas/PopulatedResourceType'
+        included:
+          type: array
+          items:
+            $ref: '#/components/schemas/FlatResourceType'
+    ParentTypeRelationship:
+      type: object
+      properties:
+        parentType:
+          $ref: '#/components/schemas/RelationshipObject'
     ResourceInstanceResponse:
       type: object
       properties:
         data:
-          $ref: '#/components/schemas/ResourceInstance'
+          $ref: '#/components/schemas/PopulatedResourceInstance'
+        included:
+          type: array
+          items:
+            $ref: '#/components/schemas/FlatResourceType'
     ResourceInstancesResponse:
       type: object
       properties:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/ResourceInstance'
+            $ref: '#/components/schemas/PopulatedResourceInstance'
+        included:
+          type: array
+          items:
+            $ref: '#/components/schemas/FlatResourceType'
+    ResourceTypeRelationship:
+      type: object
+      properties:
+        resourceType:
+          $ref: '#/components/schemas/RelationshipObject'

--- a/src/routes/resourceInstances.ts
+++ b/src/routes/resourceInstances.ts
@@ -98,7 +98,7 @@ router.post('/', async (req: express.Request, res: express.Response) => {
     const newInstanceJSON = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
     const newInstance = new ResourceInstance(newInstanceJSON);
     await newInstance.save();
-    res.status(201).send(resourceInstanceSerializer.serialize(newInstance));
+    res.status(201).send(apiSerializer(newInstance, resourceInstanceSerializer));
   } catch (error) {
     winston.error(error.message);
     res.status(500).send(createJSONError('500', 'Error in ResourceInstance-Router', error.message));

--- a/src/routes/resourceInstances.ts
+++ b/src/routes/resourceInstances.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import ResourceInstance, { resourceInstanceSerializer } from '@/models/ResourceInstance';
 import winston from 'winston';
 import { Deserializer } from 'jsonapi-serializer';
+import apiSerializer from '@/utils/apiSerializer';
 import createJSONError from '@/utils/errorSerializer';
 
 const router: express.Router = express.Router();
@@ -33,7 +34,7 @@ router.get('/', async (req: express.Request, res: express.Response) => {
       .find({})
       .populate(populateResourceTypeOptions)
       .exec();
-    res.send(resourceInstanceSerializer.serialize(resourceInstances));
+    res.send(apiSerializer(resourceInstances, resourceInstanceSerializer));
   } catch (error) {
     winston.error(error.message);
     res.status(500).send(createJSONError('500', 'Error in ResourceInstance-Router', error.message));
@@ -69,7 +70,7 @@ router.get('/:instanceId', async (req: express.Request, res: express.Response) =
       .findById(req.params.instanceId)
       .populate(populateResourceTypeOptions)
       .exec();
-    res.send(resourceInstanceSerializer.serialize(resourceInstance));
+    res.send(apiSerializer(resourceInstance, resourceInstanceSerializer));
   } catch (error) {
     winston.error(error.message);
     res.status(500).send(createJSONError('500', 'Error in ResourceInstance-Router', error.message));

--- a/src/routes/resourceTypes.ts
+++ b/src/routes/resourceTypes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import ResourceTypeModel, { resourceTypeSerializer, ResourceType } from '@/models/ResourceType';
 import winston from 'winston';
 import { Deserializer } from 'jsonapi-serializer';
+import apiSerializer from '@/utils/apiSerializer';
 import createJSONError from '@/utils/errorSerializer';
 
 const router: express.Router = express.Router();
@@ -36,7 +37,7 @@ router.get('/', async (req: express.Request, res: express.Response) => {
     for (const resourceType of resourceTypes) {
       resourceType.attributes = await resourceType.getCompleteListOfAttributes();
     }
-    res.send(resourceTypeSerializer.serialize(resourceTypes));
+    res.send(apiSerializer(resourceTypes, resourceTypeSerializer));
   } catch (error) {
     winston.error(error.message);
     res.status(500).send(createJSONError('500', 'Error in ResourceType-Router', error.message));
@@ -76,7 +77,7 @@ router.get('/:typeId', async (req: express.Request, res: express.Response) => {
       throw Error(`Resource type with id ${req.params.id} could not be found.`);
     }
     resourceType.attributes = await resourceType.getCompleteListOfAttributes();
-    res.send(resourceTypeSerializer.serialize(resourceType));
+    res.send(apiSerializer(resourceType, resourceTypeSerializer));
   } catch (error) {
     winston.error(error.message);
     res.status(500).send(createJSONError('500', 'Error in ResourceType-Router', error.message));

--- a/src/routes/resourceTypes.ts
+++ b/src/routes/resourceTypes.ts
@@ -105,7 +105,7 @@ router.post('/', async (req: express.Request, res: express.Response) => {
     const newResourceTypeJSON = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
     const newResourceType = new ResourceTypeModel(newResourceTypeJSON);
     await newResourceType.save();
-    res.status(201).send(resourceTypeSerializer.serialize(newResourceType));
+    res.status(201).send(apiSerializer(newResourceType, resourceTypeSerializer));
   } catch (error) {
     winston.error(error.message);
     res.status(500).send(createJSONError('500', 'Error in ResourceType-Router', error.message));

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -254,11 +254,33 @@
           }
         }
       },
+      "RelationshipObject": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "ResourceTypeResponse": {
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ResourceType"
+            "$ref": "#/components/schemas/PopulatedResourceType"
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FlatResourceType"
+            }
           }
         }
       },
@@ -268,8 +290,22 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ResourceType"
+              "$ref": "#/components/schemas/PopulatedResourceType"
             }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FlatResourceType"
+            }
+          }
+        }
+      },
+      "ParentTypeRelationship": {
+        "type": "object",
+        "properties": {
+          "parentType": {
+            "$ref": "#/components/schemas/RelationshipObject"
           }
         }
       },
@@ -277,7 +313,13 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ResourceInstance"
+            "$ref": "#/components/schemas/PopulatedResourceInstance"
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FlatResourceType"
+            }
           }
         }
       },
@@ -287,68 +329,61 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ResourceInstance"
+              "$ref": "#/components/schemas/PopulatedResourceInstance"
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FlatResourceType"
             }
           }
         }
       },
-      "ResourceAttribute": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/JsonApiObject"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "attributes": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "dataType",
-                  "required"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "dataType": {
-                    "type": "string"
-                  },
-                  "required": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
+      "ResourceTypeRelationship": {
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "$ref": "#/components/schemas/RelationshipObject"
           }
-        ]
+        }
+      },
+      "ResourceAttribute": {
+        "type": "object",
+        "required": [
+          "name",
+          "dataType",
+          "required"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "dataType": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
       },
       "ResourceAttributeValue": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/JsonApiObject"
+        "type": "object",
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          {
-            "type": "object",
-            "properties": {
-              "attributes": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "value"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
+          "value": {
+            "type": "string"
           }
-        ]
+        }
       },
       "ResourceInstance": {
         "allOf": [
@@ -370,11 +405,38 @@
                     "items": {
                       "$ref": "#/components/schemas/ResourceAttributeValue"
                     }
-                  },
-                  "resourceType": {
-                    "$ref": "#/components/schemas/ResourceType"
                   }
                 }
+              }
+            }
+          }
+        ]
+      },
+      "PopulatedResourceInstance": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceInstance"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "relationships": {
+                "$ref": "#/components/schemas/ResourceTypeRelationship"
+              }
+            }
+          }
+        ]
+      },
+      "FlatResourceInstance": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceInstance"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "resourceType": {
+                "type": "string"
               }
             }
           }
@@ -409,10 +471,42 @@
                     }
                   },
                   "eponymousAttribute": {
-                    "$ref": "#/components/schemas/ResourceAttribute"
-                  },
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "PopulatedResourceType": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceType"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "relationships": {
+                "$ref": "#/components/schemas/ParentTypeRelationship"
+              }
+            }
+          }
+        ]
+      },
+      "FlatResourceType": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceType"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "attributes": {
+                "type": "object",
+                "properties": {
                   "parentType": {
-                    "$ref": "#/components/schemas/ResourceType"
+                    "type": "string"
                   }
                 }
               }

--- a/src/utils/apiSerializer.ts
+++ b/src/utils/apiSerializer.ts
@@ -1,0 +1,43 @@
+import { Serializer } from 'jsonapi-serializer';
+
+export default function serialize(object: any, serializer: Serializer): any {
+  const serializedObject = serializer.serialize(object);
+  return serializeAttributes(serializedObject);
+}
+
+function serializeAttributes(serializedObject: any): any {
+  const typesToSerialize = ['parentTypes', 'resourceTypes'];
+
+  if (serializedObject.data) {
+    if (Array.isArray(serializedObject.data)) {
+      serializedObject.data.forEach((element: any) => {
+        if (typesToSerialize.includes(element.type)) {
+          const attributes = element.attributes.attributes;
+          element.attributes.attributes = serializeAttributesObject(attributes);
+        }
+      });
+    } else {
+      if (typesToSerialize.includes(serializedObject.data)) {
+        const attributes = serializedObject.data.attributes.attributes;
+        serializedObject.data.attributes.attributes = serializeAttributesObject(attributes);
+      }
+    }
+  }
+  if (serializedObject.included) {
+    serializedObject.included.forEach((element: any) => {
+      const attributes = element.attributes.attributes;
+      element.attributes.attributes = serializeAttributesObject(attributes);
+    });
+  }
+  return serializedObject;
+}
+
+function serializeAttributesObject(attributeObject: any) {
+  const serializedAttributes = attributeObject.map((attribute: any) => {
+    attribute = attribute.toJSON();
+    attribute.id = attribute._id;
+    delete attribute._id;
+    return attribute;
+  });
+  return serializedAttributes;
+}

--- a/src/utils/apiSerializer.ts
+++ b/src/utils/apiSerializer.ts
@@ -32,6 +32,10 @@ function serializeAttributesOfResourceType(serializedObject: any) {
 }
 
 function serializeAttributesObject(attributeObject: any) {
+  if (!Array.isArray(attributeObject)) {
+    return attributeObject;
+  }
+
   const serializedAttributes = attributeObject.map((attribute: any) => {
     attribute = attribute.toJSON();
     attribute.id = attribute._id;

--- a/src/utils/apiSerializer.ts
+++ b/src/utils/apiSerializer.ts
@@ -1,33 +1,32 @@
 import { Serializer } from 'jsonapi-serializer';
 
+const typesToSerialize = ['parentTypes', 'resourceTypes'];
+
 export default function serialize(object: any, serializer: Serializer): any {
   const serializedObject = serializer.serialize(object);
-  return serializeAttributes(serializedObject);
-}
-
-function serializeAttributes(serializedObject: any): any {
-  const typesToSerialize = ['parentTypes', 'resourceTypes'];
-
   if (serializedObject.data) {
-    if (Array.isArray(serializedObject.data)) {
-      serializedObject.data.forEach((element: any) => {
-        if (typesToSerialize.includes(element.type)) {
-          const attributes = element.attributes.attributes;
-          element.attributes.attributes = serializeAttributesObject(attributes);
-        }
-      });
-    } else {
-      if (typesToSerialize.includes(serializedObject.data)) {
-        const attributes = serializedObject.data.attributes.attributes;
-        serializedObject.data.attributes.attributes = serializeAttributesObject(attributes);
-      }
-    }
+    serializedObject.data = serializeAttributesOfResourceTypes(serializedObject.data);
   }
   if (serializedObject.included) {
-    serializedObject.included.forEach((element: any) => {
-      const attributes = element.attributes.attributes;
-      element.attributes.attributes = serializeAttributesObject(attributes);
+    serializedObject.included = serializeAttributesOfResourceTypes(serializedObject.included);
+  }
+  return serializedObject;
+}
+
+function serializeAttributesOfResourceTypes(serializedObject: any[] | any): any {
+  if (Array.isArray(serializedObject)) {
+    return serializedObject.map((element: any) => {
+      return serializeAttributesOfResourceType(element);
     });
+  } else {
+    return serializeAttributesOfResourceType(serializedObject);
+  }
+}
+
+function serializeAttributesOfResourceType(serializedObject: any) {
+  if (typesToSerialize.includes(serializedObject.type)) {
+    const attributes = serializedObject.attributes.attributes;
+    serializedObject.attributes.attributes = serializeAttributesObject(attributes);
   }
   return serializedObject;
 }


### PR DESCRIPTION
**This PR changes the structure of most API responses!**
For more details, please refer to the current swagger specification.

In this PR:
 * we adhere more to the json api specification. The `parentType` / `resourceType` is no longer provided as an attribute, but as a *relationship* and part of the *included* array. This makes it possible, for example, to refer several times to the same type, which is only described once in detail (saves space).
* the issue with the `_id` or `Id` keys in attributes is solved. (We now have a second, manual serialization step.)

