### PR TITLE
Hotfix/post with objects

### DIFF
--- a/src/routes/resourceInstances.ts
+++ b/src/routes/resourceInstances.ts
@@ -96,6 +96,9 @@ router.get('/:instanceId', async (req: express.Request, res: express.Response) =
 router.post('/', async (req: express.Request, res: express.Response) => {
   try {
     const newInstanceJSON = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
+    if (newInstanceJSON.resourceType.id) {
+      newInstanceJSON.resourceType = newInstanceJSON.resourceType.id;
+    }
     const newInstance = new ResourceInstance(newInstanceJSON);
     await newInstance.save();
     res.status(201).send(apiSerializer(newInstance, resourceInstanceSerializer));

--- a/src/routes/resourceTypes.ts
+++ b/src/routes/resourceTypes.ts
@@ -103,6 +103,9 @@ router.get('/:typeId', async (req: express.Request, res: express.Response) => {
 router.post('/', async (req: express.Request, res: express.Response) => {
   try {
     const newResourceTypeJSON = await new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(req.body);
+    if (newResourceTypeJSON.parentType.id) {
+      newResourceTypeJSON.parentType = newResourceTypeJSON.parentType.id;
+    }
     const newResourceType = new ResourceTypeModel(newResourceTypeJSON);
     await newResourceType.save();
     res.status(201).send(apiSerializer(newResourceType, resourceTypeSerializer));


### PR DESCRIPTION
Originally, the `parentType`/`resourceType` was provided as id to the back-end.
Now, these fields are the respective objects. So in the back-end, we need to replace the object by its id to restore the former functionality. (Solves issues regarding POST requests.)