### PR TITLE
Consistently use objectId in refs

### DIFF
--- a/src/models/ResourceInstance.ts
+++ b/src/models/ResourceInstance.ts
@@ -4,8 +4,12 @@ import ResourceAttribute from '@/models/ResourceAttribute';
 import ResourceAttributeValue from '@/models/ResourceAttributeValue';
 import { Serializer } from 'jsonapi-serializer';
 import winston from 'winston';
+import { ObjectId } from 'bson';
 
 @pre<ResourceInstance>('save', async function() {
+  if (typeof this.resourceType === 'string') {
+    this.resourceType = new ObjectId(this.resourceType);
+  }
 
   const foundType = await ResourceTypeModel.findById( this.resourceType ).exec();
 

--- a/src/models/ResourceType.ts
+++ b/src/models/ResourceType.ts
@@ -13,7 +13,7 @@ import { ObjectId } from 'bson';
 })
 
 @pre<ResourceType>('remove', async function(): Promise<void> {
-  const childTypesCount = await ResourceTypeModel.countDocuments({ parentType: this._id });
+  const childTypesCount = await ResourceTypeModel.countDocuments({ parentType: this._id }).exec();
   if (childTypesCount > 0) {
     return new Promise((resolve, reject) => {
       reject(new Error(`There are ${childTypesCount} resource types with '${this.name}' as parent. ` +
@@ -21,7 +21,7 @@ import { ObjectId } from 'bson';
     });
   }
 
-  const instancesCount = await ResourceInstanceModel.countDocuments({ resourceType: this._id });
+  const instancesCount = await ResourceInstanceModel.countDocuments({ resourceType: this._id }).exec();
   if (instancesCount > 0) {
     return new Promise((resolve, reject) => {
       reject(new Error(`There are ${instancesCount} instances of type '${this.name}'. Type can not be deleted.`));

--- a/src/utils/ResourceInstanceInitializer.ts
+++ b/src/utils/ResourceInstanceInitializer.ts
@@ -58,7 +58,7 @@ export default class ResourceInstanceInitializer {
       return;
     }
     const currentAmountOfHumans = await ResourceInstance.countDocuments({
-      resourceType: humanResourceType.id,
+      resourceType: humanResourceType._id,
     }).exec();
 
     const deviationFromTarget = targetAmountOfHumanResources - currentAmountOfHumans;
@@ -80,7 +80,7 @@ export default class ResourceInstanceInitializer {
           },
         ],
       });
-      newHumanResource.resourceType = humanResourceType.id;
+      newHumanResource.resourceType = humanResourceType._id;
       try {
         await newHumanResource.save();
         winston.debug(`Created human instance '${newName}'`);
@@ -128,7 +128,7 @@ export default class ResourceInstanceInitializer {
     }
 
     const currentAmountOfExhaustibles = await ResourceInstance.countDocuments({
-      resourceType: exhaustibleResourceType.id,
+      resourceType: exhaustibleResourceType._id,
     }).exec();
 
     const deviationFromTarget = targetAmountOfExhaustibleResources - currentAmountOfExhaustibles;
@@ -152,7 +152,7 @@ export default class ResourceInstanceInitializer {
           },
         ],
       });
-      newExhaustible.resourceType = exhaustibleResourceType.id;
+      newExhaustible.resourceType = exhaustibleResourceType._id;
       try {
         await newExhaustible.save();
         winston.debug(`Created new exhaustible resource at '${exhaustible.limit}'`);


### PR DESCRIPTION
Created instances had a string for the `resourceType` attribute, but an `objectId` would be the correct data type for storing a reference.
Now, we convert ref-strings to ObjectIds if necessary and now, all comparisons should work again.