### PR TITLE
Feature/fe 41 select eponymous

### DIFF
--- a/src/models/ResourceType.ts
+++ b/src/models/ResourceType.ts
@@ -93,8 +93,8 @@ export class ResourceType extends Typegoose {
   @arrayProp({ required: true, items: ResourceAttribute })
   public attributes: ResourceAttribute[] = [];
 
-  @prop({ ref: ResourceAttribute })
-  public eponymousAttribute?: Ref<ResourceAttribute>;
+  @prop({ required: false })
+  public eponymousAttribute?: string;
 
   @prop({ ref: ResourceType })
   public parentType?: Ref<ResourceType>;
@@ -134,9 +134,8 @@ export class ResourceType extends Typegoose {
   @instanceMethod
   public getEponymousAttribute(): ResourceAttribute | undefined {
     const attributes: ResourceAttribute[] = this.attributes;
-    const eponymousAttributeId = this.eponymousAttribute as ObjectId;
     return attributes.find((attribute: any) => {
-      return (attribute.id === eponymousAttributeId.toString());
+      return (attribute.name === this.eponymousAttribute);
     });
   }
 

--- a/src/models/ResourceType.ts
+++ b/src/models/ResourceType.ts
@@ -2,13 +2,24 @@ import { Typegoose, prop, arrayProp, Ref, pre, instanceMethod } from 'typegoose'
 import ResourceInstanceModel from '@/models/ResourceInstance';
 import ResourceAttribute from '@/models/ResourceAttribute';
 import { Serializer } from 'jsonapi-serializer';
-import { ObjectId } from 'bson';
 
 @pre<ResourceType>('save', async function(): Promise<void> {
   if (!this.parentType && this.name !== 'Resource') {
     return new Promise((resolve, reject) => {
       reject(new Error(`Parent resource type for new type '${this.name}' must be defined.`));
     });
+  }
+
+  if (this.eponymousAttribute) {
+    const allAttributes = await this.getCompleteListOfAttributes();
+    const eponymousAttributeDefined = allAttributes.some((attribute) => {
+      return attribute.name === this.eponymousAttribute;
+    });
+    if (!eponymousAttributeDefined) {
+      return new Promise((resolve, reject) => {
+        reject(new Error(`The attribute marked as eponymous '${this.eponymousAttribute}' is not defined on this resource type.`));
+      });
+    }
   }
 })
 

--- a/src/utils/RootTypeInitializer.ts
+++ b/src/utils/RootTypeInitializer.ts
@@ -1,7 +1,6 @@
 import ResourceType from '@/models/ResourceType';
 import rootTypes from '@/utils/rootTypes';
 import winston from 'winston';
-import ResourceAttribute from '@/models/ResourceAttribute';
 
 export default class RootTypeInitializer {
   // region public static methods
@@ -21,15 +20,9 @@ export default class RootTypeInitializer {
         if (rootType.parentType) {
           await resourceRootType.setParentResourceTypeByName(rootType.parentType);
         }
-        resourceRootType.eponymousAttribute = undefined;
+
         await resourceRootType.save();
-        if (rootType.eponymousAttribute) {
-          const eponymousAttributeId = resourceRootType.attributes.find((attribute: ResourceAttribute) => {
-            return (attribute.name === rootType.eponymousAttribute);
-          });
-          resourceRootType.eponymousAttribute = eponymousAttributeId;
-          await resourceRootType.save();
-        }
+
         winston.debug(`Initialized '${rootType.name}' type.`);
       } catch (error) {
         winston.error(error.message);


### PR DESCRIPTION
Change the eponymous attribute in resource type from being an id reference to string.
Now, the eponymous attribute stores the name of the attribute that should be used for naming an instance.